### PR TITLE
Drop default overflow on group

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -311,6 +311,11 @@ class SVG:
             )
             child.attrib["clip-path"] = ",".join([c for c in clips if c])
 
+        def _inherit_nondefault_overflow(attrib, child, attr_name):
+            value = attrib[attr_name]
+            if value != 'visible':
+                _inherit_copy(attrib, child, attr_name)
+
         attrib_handlers = {
             "fill": _inherit_copy,
             "stroke": _inherit_copy,
@@ -324,6 +329,7 @@ class SVG:
             "clip-path": _inherit_clip_path,
             "id": lambda *_: 0,
             "data-name": lambda *_: 0,
+            "overflow": _inherit_nondefault_overflow,
         }
 
         attrib = copy.deepcopy(group.attrib)

--- a/tests/ungroup-after.svg
+++ b/tests/ungroup-after.svg
@@ -13,6 +13,7 @@
   <use xlink:href="#r2" clip-path="url(#merged-clip-0)"
        fill="#BBBBBB" opacity="0.25" />
   <use xlink:href="#r2"
+       overflow="visible"
        stroke-linecap="round"
        stroke-miterlimit="10"
        stroke-width="0.9563" />

--- a/tests/ungroup-before.svg
+++ b/tests/ungroup-before.svg
@@ -24,7 +24,7 @@
   <g stroke-linecap="round">
     <g stroke-miterlimit="10">
       <g stroke-width="0.9563">
-        <use xlink:href="#r2" />
+        <use xlink:href="#r2" overflow="visible" />
       </g>
     </g>
   </g>


### PR DESCRIPTION
otherwise implicit group from a <use overflow="visible"/> gets angry.

Fixes #27.