### PR TITLE
Avoid crashing where a sane alternative exists

### DIFF
--- a/src/picosvg/geometric_types.py
+++ b/src/picosvg/geometric_types.py
@@ -90,13 +90,11 @@ class Vector(NamedTuple):
         return self.x * other.x + self.y * other.y
 
     def projection(self, other: "Vector") -> "Vector":
-        """Return the vector projection of self onto other vector.
-
-        Raises ValueError if other is a zero vector.
-        """
+        """Return the vector projection of self onto other vector."""
         norm = other.norm()
         if norm == 0:
-            raise ValueError(f"Can't compute projection onto zero vector: {other!r}")
+            # it is more helpful for projection onto 0 to be 0 than an error
+            return Vector()
         return self.dot(other) / norm * other.unit()
 
 

--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -229,7 +229,7 @@ class SVG:
         for use_el in self.xpath(".//svg:use", el=scope_el):
             ref = use_el.attrib.get(_xlink_href_attr_name(), "")
             if not ref.startswith("#"):
-                raise ValueError("Only use #fragment supported")
+                raise ValueError(f"Only use #fragment supported, reject {ref}")
             target = self.xpath_one(f'//svg:*[@id="{ref[1:]}"]')
 
             new_el = copy.deepcopy(target)
@@ -456,7 +456,7 @@ class SVG:
         for cleanmeup in (shape, stroke):
             _reset_attrs(cleanmeup, lambda field: field.name.startswith("stroke"))
 
-        if not shape.visible():
+        if not shape.might_paint():
             return (stroke,)
 
         return (shape, stroke)
@@ -549,8 +549,9 @@ class SVG:
                         transform, Affine2D.fromstring(el.attrib["transform"])
                     )
                 el = el.getparent()
-            if transform != Affine2D.identity():
-                new_shapes.append((idx, shape.apply_transform(transform)))
+            if transform == Affine2D.identity():
+                continue
+            new_shapes.append((idx, shape.apply_transform(transform)))
 
         for el_idx, new_shape in new_shapes:
             el, _ = self.elements[el_idx]
@@ -571,7 +572,7 @@ class SVG:
 
         remove = []
         for (el, (shape,)) in self._elements():
-            if not shape.visible():
+            if not shape.might_paint():
                 remove.append(el)
 
         for el in remove:

--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -52,6 +52,11 @@ class Affine2D(NamedTuple):
     def identity():
         return Affine2D._identity
 
+
+    @staticmethod
+    def degenerate():
+        return Affine2D._degnerate
+
     @staticmethod
     def fromstring(raw_transform):
         return parse_svg_transform(raw_transform)
@@ -119,11 +124,11 @@ class Affine2D(NamedTuple):
     def inverse(self):
         """Return the inverse Affine2D transformation.
 
-        Raises ValueError if it's degenerate and thus non-invertible."""
+        The inverse of a degenerate Affine2D is itself degenerate."""
         if self == self.identity():
             return self
         elif self.is_degenerate():
-            raise ValueError(f"Degenerate matrix is non-invertible: {self!r}")
+            return Affine2D.degenerate()
         a, b, c, d, e, f = self
         det = self.determinant()
         a, b, c, d = d / det, -b / det, -c / det, a / det
@@ -158,6 +163,7 @@ class Affine2D(NamedTuple):
 
 
 Affine2D._identity = Affine2D(1, 0, 0, 1, 0, 0)
+Affine2D._degnerate = Affine2D(0, 0, 0, 0, 0, 0)
 
 
 def _fix_rotate(args):

--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -52,7 +52,6 @@ class Affine2D(NamedTuple):
     def identity():
         return Affine2D._identity
 
-
     @staticmethod
     def degenerate():
         return Affine2D._degnerate

--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -70,24 +70,33 @@ class SVGShape:
         self.opacity = opacity
         self.transform = transform
 
-    def visible(self) -> bool:
+    def might_paint(self) -> bool:
+        """False if we're sure this shape will not paint. True if it *might* paint."""
         def _visible(fill, opacity):
             return fill != "none" and opacity != 0
             # we're ignoring fill-opacity
 
-        return _visible(self.fill, self.opacity) or _visible(
-            self.stroke, self.stroke_opacity
-        )
+        if _visible(self.stroke, self.stroke_opacity):
+            return True
+
+        if not _visible(self.fill, self.opacity):
+            return False
+
+        # if all you do is move the pen around you can't draw
+        return any(c[0].upper() != 'M' for c in self.as_cmd_seq())
+
 
     def bounding_box(self) -> Rect:
         x1, y1, x2, y2 = svg_pathops.bounding_box(self.as_cmd_seq())
         return Rect(x1, y1, x2 - x1, y2 - y1)
 
     def apply_transform(self, transform: Affine2D) -> "SVGPath":
-        cmds = svg_pathops.transform(self.as_cmd_seq(), transform)
         target = self.as_path()
         if target is self:
             target = copy.deepcopy(target)
+        cmds = (('M', (0, 0)),)
+        if not transform.is_degenerate():
+            cmds = svg_pathops.transform(self.as_cmd_seq(), transform)
         return target.update_path(cmds, inplace=True)
 
     def as_path(self) -> "SVGPath":

--- a/tests/degenerate-before.svg
+++ b/tests/degenerate-before.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+  viewBox="0 0 10 10">
+  <!-- never put the pen down -->
+  <path d="" />
+  <path d="M5,6" />
+  
+  <!-- what a lovely rect! -->
+  <rect id="a_rect" x="1" y="1" width="1" height="1" />
+
+  <!-- sure would be a shame if someone scaled it away! -->
+  <use xlink:href="#a_rect" transform="scale(0, 2)" />
+
+</svg>

--- a/tests/degenerate-nano.svg
+++ b/tests/degenerate-nano.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512"
+  viewBox="0 0 10 10">
+  <defs/>
+  <path id="a_rect" d="M1,1 H2 V2 H1 V1 z"/>
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -243,6 +243,7 @@ def test_transform(actual, expected_result):
         ("transform-before.svg", "transform-nano.svg"),
         ("group-data-name-before.svg", "group-data-name-after.svg"),
         ("matrix-before.svg", "matrix-nano.svg"),
+        ("degenerate-before.svg", "degenerate-nano.svg"),
     ],
 )
 def test_topicosvg(actual, expected_result):

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -81,7 +81,16 @@ class TestAffine2D:
 
     def test_is_degenerate(self):
         assert not Affine2D(1, 2, 3, 4, 5, 6).is_degenerate()
+        assert not Affine2D.identity().is_degenerate()
+        assert Affine2D.degenerate().is_degenerate()
         assert Affine2D(-1, 2 / 3, 3 / 2, -1, 0, 0).is_degenerate()
+        assert Affine2D(float_info.epsilon, float_info.epsilon, float_info.epsilon, float_info.epsilon, 0, 0).is_degenerate()
+
+    def test_scale_0_is_degenerate(self):
+        assert not Affine2D.identity().scale(1, 1).is_degenerate()
+        assert Affine2D.identity().scale(0, 1).is_degenerate()
+        assert Affine2D.identity().scale(1, 0).is_degenerate()
+        assert Affine2D.identity().scale(0, 0).is_degenerate()
 
     def test_inverse(self):
         t = Affine2D.identity().translate(2, 3).scale(4, 5)
@@ -91,8 +100,9 @@ class TestAffine2D:
         p2 = it.map_point(p1)
         assert p2 == p0
 
-        with pytest.raises(ValueError, match="non-invertible"):
-            Affine2D(1, 1, 1, 1, 0, 0).inverse()
+        assert Affine2D.degenerate().inverse() == Affine2D.degenerate()
+        t = Affine2D(1, 1, 1, 1, 0, 0).inverse()
+        assert t.is_degenerate()
 
     @pytest.mark.parametrize(
         "src, dest, expected",
@@ -146,3 +156,4 @@ class TestAffine2D:
         assert af.getscale() == (1, 1)
         af = af.scale(2, 3)
         assert af.getscale() == (2, 3)
+

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -84,7 +84,14 @@ class TestAffine2D:
         assert not Affine2D.identity().is_degenerate()
         assert Affine2D.degenerate().is_degenerate()
         assert Affine2D(-1, 2 / 3, 3 / 2, -1, 0, 0).is_degenerate()
-        assert Affine2D(float_info.epsilon, float_info.epsilon, float_info.epsilon, float_info.epsilon, 0, 0).is_degenerate()
+        assert Affine2D(
+            float_info.epsilon,
+            float_info.epsilon,
+            float_info.epsilon,
+            float_info.epsilon,
+            0,
+            0,
+        ).is_degenerate()
 
     def test_scale_0_is_degenerate(self):
         assert not Affine2D.identity().scale(1, 1).is_degenerate()
@@ -156,4 +163,3 @@ class TestAffine2D:
         assert af.getscale() == (1, 1)
         af = af.scale(2, 3)
         assert af.getscale() == (2, 3)
-

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -156,11 +156,7 @@ def test_arcs_to_cubics(path, expected_result):
             "M3,2 L4,2 L4,3 L3,3 Z",
         ),
         # same shape as above under a degenerate transform
-        (
-            "M1,1 L2,1 L2,2 L1,2 Z",
-            Affine2D.degenerate(),
-            "M0,0",
-        ),
+        ("M1,1 L2,1 L2,2 L1,2 Z", Affine2D.degenerate(), "M0,0",),
     ],
 )
 def test_apply_basic_transform(path, transform, expected_result):
@@ -173,23 +169,11 @@ def test_apply_basic_transform(path, transform, expected_result):
 @pytest.mark.parametrize(
     "path, expected_result",
     [
-        (
-            SVGRect(width=1, height=1),
-            True
-        ),
+        (SVGRect(width=1, height=1), True),
         # we see paths with move and nothing else in the wild
-        (
-            SVGPath(d="M1,2"),
-            False
-        ),
-        (
-            SVGPath(d="M1,2 M3,4"),
-            False
-        ),
-        (
-            SVGPath(d="M1,2 L3,4 Z"),
-            True
-        ),
+        (SVGPath(d="M1,2"), False),
+        (SVGPath(d="M1,2 M3,4"), False),
+        (SVGPath(d="M1,2 L3,4 Z"), True),
     ],
 )
 def test_might_paint(path, expected_result):

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import pytest
-from picosvg.svg_types import SVGPath, Rect
+from picosvg.svg_transform import Affine2D
+from picosvg.svg_types import SVGPath, SVGRect, Rect
 from svg_test_helpers import *
 
 
@@ -143,3 +144,53 @@ def test_arcs_to_cubics(path, expected_result):
     print(f"A: {actual}")
     print(f"E: {expected_result}")
     assert actual == expected_result
+
+
+@pytest.mark.parametrize(
+    "path, transform, expected_result",
+    [
+        # translate
+        (
+            "M1,1 L2,1 L2,2 L1,2 Z",
+            Affine2D.identity().translate(2, 1),
+            "M3,2 L4,2 L4,3 L3,3 Z",
+        ),
+        # same shape as above under a degenerate transform
+        (
+            "M1,1 L2,1 L2,2 L1,2 Z",
+            Affine2D.degenerate(),
+            "M0,0",
+        ),
+    ],
+)
+def test_apply_basic_transform(path, transform, expected_result):
+    actual = SVGPath(d=path).apply_transform(transform).d
+    print(f"A: {actual}")
+    print(f"E: {expected_result}")
+    assert actual == expected_result
+
+
+@pytest.mark.parametrize(
+    "path, expected_result",
+    [
+        (
+            SVGRect(width=1, height=1),
+            True
+        ),
+        # we see paths with move and nothing else in the wild
+        (
+            SVGPath(d="M1,2"),
+            False
+        ),
+        (
+            SVGPath(d="M1,2 M3,4"),
+            False
+        ),
+        (
+            SVGPath(d="M1,2 L3,4 Z"),
+            True
+        ),
+    ],
+)
+def test_might_paint(path, expected_result):
+    assert path.might_paint() == expected_result, path


### PR DESCRIPTION
Trying to define ops with degenerate cases in ways that aren't raise an error.