### PR TITLE
add support for inline element-specific CSS style attributes

### DIFF
--- a/tests/inline-css-style-after.svg
+++ b/tests/inline-css-style-after.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" enable-background="new 0 0 128 128">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="5" y2="5" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop offset="0.0" stop-color="red"/>
+      <stop offset="1.0" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <rect width="10" height="10" fill="url(#g1)"/>
+  <path d="M2,2 v6 h6 v-6 h-6 z" stroke="#FF0000" stroke-width="0.5" fill="none"/>
+</svg>

--- a/tests/inline-css-style-before.svg
+++ b/tests/inline-css-style-before.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" style="enable-background:new 0 0 128 128;">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="5" y2="5" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop offset="0.0" style="stop-color:red"/>
+      <stop offset="1.0" style="stop-color:blue"/>
+    </linearGradient>
+  </defs>
+  <rect width="10" height="10" style="fill:url(#g1);"/>
+  <path d="M2,2 v6 h6 v-6 h-6 z" style="stroke:#FF0000;stroke-width:0.5;fill:none;"/>
+</svg>

--- a/tests/inline-css-style-nano.svg
+++ b/tests/inline-css-style-nano.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" enable-background="new 0 0 128 128">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="5" y2="5" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+      <stop offset="0.0" stop-color="red"/>
+      <stop offset="1.0" stop-color="blue"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#g1)" d="M0,0 H10 V10 H0 V0 z"/>
+  <path fill="#FF0000" d="M1.75,1.75 L1.75,8.25 L8.25,8.25 L8.25,1.75 Z M2.25,2.25 L7.75,2.25 L7.75,7.75 L2.25,7.75 Z"/>
+</svg>
+

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -156,7 +156,7 @@ def test_arcs_to_cubics(path, expected_result):
             "M3,2 L4,2 L4,3 L3,3 Z",
         ),
         # same shape as above under a degenerate transform
-        ("M1,1 L2,1 L2,2 L1,2 Z", Affine2D.degenerate(), "M0,0",),
+        ("M1,1 L2,1 L2,2 L1,2 Z", Affine2D.degenerate(), "M0,0"),
     ],
 )
 def test_apply_basic_transform(path, transform, expected_result):
@@ -178,3 +178,30 @@ def test_apply_basic_transform(path, transform, expected_result):
 )
 def test_might_paint(path, expected_result):
     assert path.might_paint() == expected_result, path
+
+
+@pytest.mark.parametrize(
+    "shape, expected",
+    [
+        (
+            SVGRect(width=10, height=10, style="fill:red;opacity:0.5;"),
+            SVGRect(width=10, height=10, fill="red", opacity=0.5),
+        ),
+        (
+            SVGPath(
+                d="M0,0 L10,0 L10,10 L0,10 Z",
+                style="stroke:blue;stroke-opacity:0.8;filter:url(#x);",
+            ),
+            SVGPath(
+                d="M0,0 L10,0 L10,10 L0,10 Z",
+                stroke="blue",
+                stroke_opacity=0.8,
+                style="filter:url(#x);",
+            ),
+        ),
+    ],
+)
+def test_apply_style_attribute(shape, expected):
+    actual = shape.apply_style_attribute()
+    assert actual == expected
+    assert shape.apply_style_attribute(inplace=True) == expected


### PR DESCRIPTION
Fixes https://github.com/googlefonts/picosvg/issues/59

SVG elements can have a `style` attribute containing a string formatted as CSS declaration list.

https://www.w3.org/TR/SVG/styling.html#ElementSpecificStyling

In noto-emoji's emoji_u1f469_1f3fd_200d_1f33e.svg and others, this is used in several SVG shapes, in the root svg element and in the linear and radial gradients' stop-colors.

In this PR, we parse these `style` attributes and replace them with the equivalent SVG element attributes upon converting to picosvg.

SVGShape dataclasses gain a new 'style' attribute so we can parse and retain that if needed. The `SVGShape.apply_style_attribute()` method will parse the embedded CSS declarations and convert them to equivalent SVG element attributes, leaving the style attribute itself empty (or only containing remaining style properties for which no corresponding dataclass fields are currently defined).