### PR TITLE
add SVGPathPen and draw method to SVGPath to support FontTools Pen API

### DIFF
--- a/src/picosvg/svg_path_pen.py
+++ b/src/picosvg/svg_path_pen.py
@@ -1,6 +1,5 @@
 import itertools
-from typing import Any, Mapping, Optional
-from fontTools.pens.basePen import DecomposingPen
+from typing import Optional
 from picosvg.svg_types import SVGPath
 from picosvg.svg_pathops import _qcurveto_to_svg
 
@@ -8,30 +7,19 @@ from picosvg.svg_pathops import _qcurveto_to_svg
 # NOTE: the FontTools Pens API uses camelCase for the method names
 
 
-class SVGPathPen(DecomposingPen):
+class SVGPathPen:
     """A FontTools Pen that draws onto a picosvg SVGPath.
 
-    The pen automatically decomposes components using the provided `glyphSet`
-    mapping.
+    NOTE: The `addComponent` method is not supported and will raise TypeError.
+    You should decompose components before drawing a UFO or TrueType glyph with the
+    SVGPathPen (e.g.  using fontTools.recordingPen.DecomposingRecordingPen).
 
     Args:
-        glyphSet: a mapping of {glyph_name: glyph} to be used for resolving
-            component references when the pen's `addComponent` method is called.
-            (inherited from super-class). Can be set to empty dict if drawing
-            simple contours without any components.
         path: an existing SVGPath to extend with drawing commands. If None, a new
             SVGPath is created by default, accessible with the `path` attribute.
     """
 
-    # makes DecomposingPen raise 'KeyError' when component base is missing
-    skipMissingComponents = False
-
-    def __init__(
-        self,
-        glyphSet: Mapping[str, Any],
-        path: Optional[SVGPath] = None,
-    ):
-        super().__init__(glyphSet)
+    def __init__(self, path: Optional[SVGPath] = None):
         self.path = path or SVGPath()
 
     def moveTo(self, pt):
@@ -54,3 +42,6 @@ class SVGPathPen(DecomposingPen):
 
     def endPath(self):
         pass
+
+    def addComponent(self, glyphName, transformation):
+        raise TypeError("Can't add component to SVGPath; should decompose it first")

--- a/src/picosvg/svg_path_pen.py
+++ b/src/picosvg/svg_path_pen.py
@@ -1,0 +1,56 @@
+import itertools
+from typing import Any, Mapping, Optional
+from fontTools.pens.basePen import DecomposingPen
+from picosvg.svg_types import SVGPath
+from picosvg.svg_pathops import _qcurveto_to_svg
+
+
+# NOTE: the FontTools Pens API uses camelCase for the method names
+
+
+class SVGPathPen(DecomposingPen):
+    """A FontTools Pen that draws onto a picosvg SVGPath.
+
+    The pen automatically decomposes components using the provided `glyphSet`
+    mapping.
+
+    Args:
+        glyphSet: a mapping of {glyph_name: glyph} to be used for resolving
+            component references when the pen's `addComponent` method is called.
+            (inherited from super-class). Can be set to empty dict if drawing
+            simple contours without any components.
+        path: an existing SVGPath to extend with drawing commands. If None, a new
+            SVGPath is created by default, accessible with the `path` attribute.
+    """
+
+    # makes DecomposingPen raise 'KeyError' when component base is missing
+    skipMissingComponents = False
+
+    def __init__(
+        self,
+        glyphSet: Mapping[str, Any],
+        path: Optional[SVGPath] = None,
+    ):
+        super().__init__(glyphSet)
+        self.path = path or SVGPath()
+
+    def moveTo(self, pt):
+        self.path.M(*pt)
+
+    def lineTo(self, pt):
+        self.path.L(*pt)
+
+    def curveTo(self, *points):
+        # flatten sequence of point tuples
+        self.path.C(*itertools.chain.from_iterable(points))
+
+    def qCurveTo(self, *points):
+        # handle TrueType quadratic splines with implicit on-curve mid-points
+        for _, args in _qcurveto_to_svg(points):
+            self.path.Q(*args)
+
+    def closePath(self):
+        self.path._add("Z")
+
+    def endPath(self):
+        pass

--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -182,6 +182,12 @@ class SVGPath(SVGShape, svg_meta.SVGCommandSeq):
     def l(self, *args):
         self._add_cmd("L", *args)
 
+    def C(self, *args):
+        self._add_cmd("C", *args)
+
+    def Q(self, *args):
+        self._add_cmd("Q", *args)
+
     def end(self):
         self._add("z")
 

--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -421,27 +421,11 @@ class SVGPath(SVGShape, svg_meta.SVGCommandSeq):
 
     # FontTools Pens API (using camelCase for consistency with that)
 
-    def getPen(self, *, glyphSet=None):
-        """Return a FontTools Segment Pen that draws onto self.
-
-        Args:
-            glyphSet: optional mapping {glyph_name: glyph} for resolving component
-                references.
-        """
+    def getPen(self):
+        """Return a FontTools Segment Pen that draws onto self."""
         from picosvg.svg_path_pen import SVGPathPen
 
-        return SVGPathPen(glyphSet or {}, self)
-
-    def getPointPen(self, *, glyphSet=None):
-        """Return a FontTools Point Pen that draws onto self.
-
-        Args:
-            glyphSet: optional mapping {glyph_name: glyph} for resolving component
-                references.
-        """
-        from fontTools.pens.pointPen import PointToSegmentPen
-
-        return PointToSegmentPen(self.getPen(glyphSet=glyphSet))
+        return SVGPathPen(self)
 
     _SVG_CMD_TO_PEN_METHOD = {
         "M": "moveTo",
@@ -475,12 +459,6 @@ class SVGPath(SVGShape, svg_meta.SVGCommandSeq):
 
         if not closed:
             pen.endPath()
-
-    def drawPoints(self, pointPen):
-        """Draw SVGPath using a FontTools Point Pen."""
-        from fontTools.pens.pointPen import SegmentToPointPen
-
-        return self.draw(SegmentToPointPen(pointPen))
 
 
 # https://www.w3.org/TR/SVG11/shapes.html#CircleElement

--- a/tests/svg_path_pen_test.py
+++ b/tests/svg_path_pen_test.py
@@ -1,0 +1,63 @@
+from picosvg.svg_transform import Affine2D
+from picosvg.svg_types import SVGPath
+from picosvg.svg_path_pen import SVGPathPen
+import pytest
+
+
+class DummyGlyph:
+
+    def draw(self, pen):
+        pen.moveTo((0, 0))
+        pen.lineTo((0, 10))
+        pen.lineTo((10, 10))
+        pen.lineTo((10, 0))
+        pen.closePath()
+
+        pen.moveTo((0, 15))
+        pen.curveTo((0, 20), (10, 20), (10, 15))
+        pen.closePath()
+
+        pen.moveTo((0, -5))
+        pen.qCurveTo((0, -8), (3, -10), (7, -10), (10, -8), (10, -5))
+        pen.endPath()
+
+
+def test_addComponent_decompose():
+    pen = SVGPathPen(glyphSet={"a": DummyGlyph()})
+    pen.addComponent("a", Affine2D.identity())
+
+    assert pen.path.d == (
+        "M0,0 L0,10 L10,10 L10,0 Z "
+        "M0,15 C0,20 10,20 10,15 Z "
+        "M0,-5 Q0,-8 1.5,-9 Q3,-10 5,-10 Q7,-10 8.5,-9 Q10,-8 10,-5"
+    )
+
+
+def test_addComponent_decompose_with_transform():
+    pen = SVGPathPen(glyphSet={"a": DummyGlyph()})
+    pen.addComponent("a", Affine2D(2, 0, 0, 2, 0, 0))
+
+    assert pen.path.d == (
+        "M0,0 L0,20 L20,20 L20,0 Z "
+        "M0,30 C0,40 20,40 20,30 Z "
+        "M0,-10 Q0,-16 3,-18 Q6,-20 10,-20 Q14,-20 17,-18 Q20,-16 20,-10"
+    )
+
+
+def test_draw_onto_existing_path():
+    path = SVGPath(d="M0,0 L0,10 L10,10 L10,0 Z")
+    pen = SVGPathPen(glyphSet={}, path=path)
+
+    pen.moveTo((0, 15))
+    pen.lineTo((5, 20))
+    pen.lineTo((10, 15))
+    pen.closePath()
+
+    assert path.d == "M0,0 L0,10 L10,10 L10,0 Z M0,15 L5,20 L10,15 Z"
+
+
+def test_addComponent_missing():
+    pen = SVGPathPen(glyphSet={})
+
+    with pytest.raises(KeyError):
+        pen.addComponent("b", Affine2D.identity())

--- a/tests/svg_path_pen_test.py
+++ b/tests/svg_path_pen_test.py
@@ -4,27 +4,22 @@ from picosvg.svg_path_pen import SVGPathPen
 import pytest
 
 
-class DummyGlyph:
+def test_draw_new_path():
+    pen = SVGPathPen()
 
-    def draw(self, pen):
-        pen.moveTo((0, 0))
-        pen.lineTo((0, 10))
-        pen.lineTo((10, 10))
-        pen.lineTo((10, 0))
-        pen.closePath()
+    pen.moveTo((0, 0))
+    pen.lineTo((0, 10))
+    pen.lineTo((10, 10))
+    pen.lineTo((10, 0))
+    pen.closePath()
 
-        pen.moveTo((0, 15))
-        pen.curveTo((0, 20), (10, 20), (10, 15))
-        pen.closePath()
+    pen.moveTo((0, 15))
+    pen.curveTo((0, 20), (10, 20), (10, 15))
+    pen.closePath()
 
-        pen.moveTo((0, -5))
-        pen.qCurveTo((0, -8), (3, -10), (7, -10), (10, -8), (10, -5))
-        pen.endPath()
-
-
-def test_addComponent_decompose():
-    pen = SVGPathPen(glyphSet={"a": DummyGlyph()})
-    pen.addComponent("a", Affine2D.identity())
+    pen.moveTo((0, -5))
+    pen.qCurveTo((0, -8), (3, -10), (7, -10), (10, -8), (10, -5))
+    pen.endPath()
 
     assert pen.path.d == (
         "M0,0 L0,10 L10,10 L10,0 Z "
@@ -33,20 +28,9 @@ def test_addComponent_decompose():
     )
 
 
-def test_addComponent_decompose_with_transform():
-    pen = SVGPathPen(glyphSet={"a": DummyGlyph()})
-    pen.addComponent("a", Affine2D(2, 0, 0, 2, 0, 0))
-
-    assert pen.path.d == (
-        "M0,0 L0,20 L20,20 L20,0 Z "
-        "M0,30 C0,40 20,40 20,30 Z "
-        "M0,-10 Q0,-16 3,-18 Q6,-20 10,-20 Q14,-20 17,-18 Q20,-16 20,-10"
-    )
-
-
 def test_draw_onto_existing_path():
     path = SVGPath(d="M0,0 L0,10 L10,10 L10,0 Z")
-    pen = SVGPathPen(glyphSet={}, path=path)
+    pen = SVGPathPen(path)
 
     pen.moveTo((0, 15))
     pen.lineTo((5, 20))
@@ -56,8 +40,8 @@ def test_draw_onto_existing_path():
     assert path.d == "M0,0 L0,10 L10,10 L10,0 Z M0,15 L5,20 L10,15 Z"
 
 
-def test_addComponent_missing():
-    pen = SVGPathPen(glyphSet={})
+def test_addComponent_raise_TypeError():
+    pen = SVGPathPen()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
         pen.addComponent("b", Affine2D.identity())

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -178,3 +178,29 @@ def test_apply_basic_transform(path, transform, expected_result):
 )
 def test_might_paint(path, expected_result):
     assert path.might_paint() == expected_result, path
+
+
+_TEST_PATHS = [
+    "M0,0 L0,10 L10,10 L10,0 Z",
+    "M0,0 L0,10 L10,10 L10,0",
+    "M0,0 L0,10 L10,10 L10,0 Z M12,0 L12,10 L22,10 L22,0",
+    "M0,0 L0,10 L10,10 L10,0 M12,0 L12,10 L22,10 L22,0 Z",
+    "M0,0 C0,3 2,5 5,5 C8,5 10,3 10,0 C10,-3 8,-5 5,-5 C2,-5 0,-3 0,0 Z",
+    "M0,0 Q0,10 10,10 Q20,10 20,0 Z"
+]
+
+
+@pytest.mark.parametrize("path", _TEST_PATHS)
+def test_roundtrip_path_with_pen(path):
+    original = SVGPath(d=path)
+    new = SVGPath()
+    original.draw(new.getPen())
+    assert new.d == original.d
+
+
+@pytest.mark.parametrize("path", _TEST_PATHS)
+def test_roundtrip_path_with_point_pen(path):
+    original = SVGPath(d=path)
+    new = SVGPath()
+    original.drawPoints(new.getPointPen())
+    assert new.d == original.d

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -156,7 +156,7 @@ def test_arcs_to_cubics(path, expected_result):
             "M3,2 L4,2 L4,3 L3,3 Z",
         ),
         # same shape as above under a degenerate transform
-        ("M1,1 L2,1 L2,2 L1,2 Z", Affine2D.degenerate(), "M0,0",),
+        ("M1,1 L2,1 L2,2 L1,2 Z", Affine2D.degenerate(), "M0,0"),
     ],
 )
 def test_apply_basic_transform(path, transform, expected_result):
@@ -180,27 +180,19 @@ def test_might_paint(path, expected_result):
     assert path.might_paint() == expected_result, path
 
 
-_TEST_PATHS = [
-    "M0,0 L0,10 L10,10 L10,0 Z",
-    "M0,0 L0,10 L10,10 L10,0",
-    "M0,0 L0,10 L10,10 L10,0 Z M12,0 L12,10 L22,10 L22,0",
-    "M0,0 L0,10 L10,10 L10,0 M12,0 L12,10 L22,10 L22,0 Z",
-    "M0,0 C0,3 2,5 5,5 C8,5 10,3 10,0 C10,-3 8,-5 5,-5 C2,-5 0,-3 0,0 Z",
-    "M0,0 Q0,10 10,10 Q20,10 20,0 Z"
-]
-
-
-@pytest.mark.parametrize("path", _TEST_PATHS)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "M0,0 L0,10 L10,10 L10,0 Z",
+        "M0,0 L0,10 L10,10 L10,0",
+        "M0,0 L0,10 L10,10 L10,0 Z M12,0 L12,10 L22,10 L22,0",
+        "M0,0 L0,10 L10,10 L10,0 M12,0 L12,10 L22,10 L22,0 Z",
+        "M0,0 C0,3 2,5 5,5 C8,5 10,3 10,0 C10,-3 8,-5 5,-5 C2,-5 0,-3 0,0 Z",
+        "M0,0 Q0,10 10,10 Q20,10 20,0 Z",
+    ],
+)
 def test_roundtrip_path_with_pen(path):
     original = SVGPath(d=path)
     new = SVGPath()
     original.draw(new.getPen())
-    assert new.d == original.d
-
-
-@pytest.mark.parametrize("path", _TEST_PATHS)
-def test_roundtrip_path_with_point_pen(path):
-    original = SVGPath(d=path)
-    new = SVGPath()
-    original.drawPoints(new.getPointPen())
     assert new.d == original.d


### PR DESCRIPTION
This is useful in nanoemoji when converting COLR->SVG, as well as in general for better interoperability with existing libs that support the FontTools pen interface.