### PR TITLE
Round gradient transforms avoid imprecision

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -732,8 +732,11 @@ class SVG:
             gradient = _GRADIENT_CLASSES[strip_ns(el.tag)].from_element(
                 el, self.view_box()
             )
-            affine = gradient.gradientTransform
-            a, b, c, d, e, f = affine
+            a, b, c, d, e, f = (
+                round(v, _GRADIENT_TRANSFORM_NDIGITS)
+                for v in gradient.gradientTransform
+            )
+            affine = Affine2D(a, b, c, d, e, f)
             #  no translate? nop!
             if (e, f) == (0, 0):
                 continue

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -442,6 +442,12 @@ def test_apply_style_attributes(actual, expected_result):
             '<radialGradient id="f" cx="-779.79" cy="3150" r="58.471" gradientTransform="matrix(0 1 -1 0 3082.5 1129.5)" gradientUnits="userSpaceOnUse"/>',
             '<radialGradient id="f" cx="349.71" cy="67.5" r="58.471" gradientTransform="matrix(0 1 -1 0 0 0)" gradientUnits="userSpaceOnUse"/>',
         ),
+        # Real example from emoji_u270c.svg
+        # Very small values (e-17...) and float math makes for large errors
+        (
+            '<radialGradient id="f" cx="75.915" cy="20.049" r="71.484" fx="88.617" fy="-50.297" gradientTransform="matrix(6.1232e-17 1 -1.0519 6.4408e-17 97.004 -55.866)" gradientUnits="userSpaceOnUse"/>',
+            '<radialGradient id="f" cx="20.049" cy="-72.168891" r="71.484" fx="32.751" fy="-142.514891" gradientTransform="matrix(0 1 -1.0519 0 0 0)" gradientUnits="userSpaceOnUse"/>',
+        ),
     ],
 )
 def test_apply_gradient_translation(gradient_string, expected_result):


### PR DESCRIPTION
Very small values don't work out all that well.

Fixes picosvg for quite a lot of Noto Emoji; https://github.com/googlefonts/color-fonts/issues/10#issuecomment-725838351