### PR TITLE
Drop anonymous <symbol>

### DIFF
--- a/tests/drop-anon-symbols-after.svg
+++ b/tests/drop-anon-symbols-after.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 128 128" viewBox="0 0 128 128">
+  <defs/>
+  <path d="M5,5 H30 V12 H5 V5 Z"/>
+</svg>

--- a/tests/drop-anon-symbols-before.svg
+++ b/tests/drop-anon-symbols-before.svg
@@ -1,0 +1,8 @@
+<svg enable-background="new 0 0 128 128" viewBox="0 0 128 128"
+  xmlns="http://www.w3.org/2000/svg">
+  <symbol viewBox="-64.5 -64.5 129 129">
+    <rect x="-64" y="-64" width="128" height="128"/>
+  </symbol>
+  <rect x="5" y="5" width="25" height="7" />
+</svg>
+  

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -263,6 +263,7 @@ def test_transform(actual, expected_result):
         ("twemoji-lesotho-flag-before.svg", "twemoji-lesotho-flag-nano.svg"),
         ("inline-css-style-before.svg", "inline-css-style-nano.svg"),
         ("clipped-strokes-before.svg", "clipped-strokes-nano.svg"),
+        ("drop-anon-symbols-before.svg", "drop-anon-symbols-after.svg"),
     ],
 )
 def test_topicosvg(actual, expected_result):
@@ -282,11 +283,7 @@ def test_remove_unpainted_shapes(actual, expected_result):
         ("good-defs-0.svg", ()),
         (
             "bad-defs-0.svg",
-            (
-                "BadElement: /svg[0]/defs[1]",
-                "BadElement: /svg[0]/donkey[2]",
-                "BadElement: /svg[0]/defs[1]/path[0]",
-            ),
+            ("BadElement: /svg[0]/defs[1]", "BadElement: /svg[0]/donkey[2]",),
         ),
         ("bad-defs-1.svg", ("BadElement: /svg[0]/path[0]",)),
     ],


### PR DESCRIPTION
Reduces the need to support symbol (#46). Merge after #133 (built on top). Helps with https://github.com/googlefonts/color-fonts/issues/10#issuecomment-725838351.