### PR TITLE
SVGShape::might_paint() return False if display=none

### DIFF
--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -140,6 +140,7 @@ class SVGShape:
     opacity: float = 1.0
     transform: str = ""
     style: str = ""
+    display: str = "inline"
 
     def _copy_common_fields(
         self,
@@ -159,6 +160,7 @@ class SVGShape:
         opacity,
         transform,
         style,
+        display,
     ):
         self.id = id
         self.clip_path = clip_path
@@ -176,9 +178,15 @@ class SVGShape:
         self.opacity = opacity
         self.transform = transform
         self.style = style
+        self.display = display
 
     def might_paint(self) -> bool:
         """False if we're sure this shape will not paint. True if it *might* paint."""
+
+        shape = self.apply_style_attribute()
+
+        if shape.display == "none":
+            return False
 
         def _visible(fill, opacity):
             return fill != "none" and opacity != 0
@@ -188,8 +196,8 @@ class SVGShape:
         if all(c[0].upper() == "M" for c in self.as_cmd_seq()):
             return False
 
-        return _visible(self.stroke, self.stroke_opacity) or _visible(
-            self.fill, self.opacity
+        return _visible(shape.stroke, shape.stroke_opacity) or _visible(
+            shape.fill, shape.opacity
         )
 
     def bounding_box(self) -> Rect:

--- a/tests/invisible-before.svg
+++ b/tests/invisible-before.svg
@@ -9,4 +9,6 @@
         fill="none" stroke="red" />
   <path d="M0,5 L200,200"
         fill="none" stroke="yellow" stroke-opacity="0" />
+  <path d="M1,1 L2,1 L2,2 L1,2 Z" display="none" />
+  <path d="M1,1 L2,1 L2,2 L1,2 Z" style="display:none;fill:#F5FAFC;" />
 </svg>

--- a/tests/svg_types_test.py
+++ b/tests/svg_types_test.py
@@ -210,6 +210,8 @@ def test_apply_basic_transform(path, transform, expected_result):
         (SVGPath(d="M1,2"), False),
         (SVGPath(d="M1,2 M3,4"), False),
         (SVGPath(d="M1,2 L3,4 Z"), True),
+        (SVGPath(d="M1,1 L2,1 L2,2 L1,2 Z", display="none"), False),
+        (SVGPath(style="display:none;fill:#F5FAFC;", d="M1,1 L2,1 L2,2 L1,2 Z"), False),
     ],
 )
 def test_might_paint(path, expected_result):


### PR DESCRIPTION
Fixes noto-emoji/svg/emoji_u1f479.svg containing an invisible path that should not be painted

Before:

![image](https://user-images.githubusercontent.com/6939968/99839198-3cb1b280-2b62-11eb-9f27-14db04cdf365.png)


After:

![image](https://user-images.githubusercontent.com/6939968/99839202-3e7b7600-2b62-11eb-84a6-7ba4cf88023a.png)
