### PR TITLE
Add an API to destroy content outside the viewbox

### DIFF
--- a/src/picosvg/geometric_types.py
+++ b/src/picosvg/geometric_types.py
@@ -119,3 +119,18 @@ class Rect(NamedTuple):
     def empty(self) -> bool:
         """Return True if the Rect's width or height is 0."""
         return self.w == 0 or self.h == 0
+
+    def intersection(self, other: "Rect") -> Optional["Rect"]:
+        def _overlap(start1, end1, start2, end2):
+            start = max(start1, start2)
+            end = min(end1, end2)
+            if start >= end:
+                return (0., 0.)
+            return (start, end)
+
+        x1, x2 = _overlap(self.x, self.x + self.w, other.x, other.x + other.w)
+        y1, y2 = _overlap(self.y, self.y + self.h, other.y, other.y + other.h)
+
+        if x1 != x2 and y1 != y2:
+            return Rect(x1, y1, x2 - x1, y2 - y1)
+        return None

--- a/src/picosvg/geometric_types.py
+++ b/src/picosvg/geometric_types.py
@@ -125,7 +125,7 @@ class Rect(NamedTuple):
             start = max(start1, start2)
             end = min(end1, end2)
             if start >= end:
-                return (0., 0.)
+                return (0.0, 0.0)
             return (start, end)
 
         x1, x2 = _overlap(self.x, self.x + self.w, other.x, other.x + other.w)

--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -622,6 +622,7 @@ class SVG:
         for idx, (el, (shape,)) in enumerate(self._elements()):
             bbox = shape.bounding_box()
             isct = view_box.intersection(bbox)
+            assert isct is not None, f"We should have already dumped {shape}"
             if bbox == isct:
                 continue
             clip_path = (

--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -600,7 +600,6 @@ class SVG:
 
         return self
 
-
     def clip_to_viewbox(self, inplace=False):
         if not inplace:
             svg = SVG(copy.deepcopy(self.svg_root))
@@ -625,7 +624,11 @@ class SVG:
             isct = view_box.intersection(bbox)
             if bbox == isct:
                 continue
-            clip_path = SVGRect(x=isct.x, y=isct.y, width=isct.w, height=isct.h).as_path().absolute(inplace=True)
+            clip_path = (
+                SVGRect(x=isct.x, y=isct.y, width=isct.w, height=isct.h)
+                .as_path()
+                .absolute(inplace=True)
+            )
             shape = shape.as_path().absolute(inplace=True)
             shape.update_path(intersection((shape, clip_path)), inplace=True)
             updates.append((idx, el, shape))
@@ -637,7 +640,6 @@ class SVG:
         self._update_etree()
 
         return self
-
 
     def apply_transforms(self, inplace=False):
         """Naively transforms to shapes and removes the transform attribute.

--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -793,17 +793,13 @@ class SVGRadialGradient:
         return self
 
 
-def union(shapes: Iterable[SVGShape]) -> SVGPath:
-    return SVGPath.from_commands(
-        svg_pathops.union(
-            [s.as_cmd_seq() for s in shapes], [s.clip_rule for s in shapes]
-        )
+def union(shapes: Iterable[SVGShape]) -> Generator[SVGCommand, None, None]:
+    return svg_pathops.union(
+        [s.as_cmd_seq() for s in shapes], [s.clip_rule for s in shapes]
     )
 
 
-def intersection(shapes: Iterable[SVGShape]) -> SVGPath:
-    return SVGPath.from_commands(
-        svg_pathops.intersection(
-            [s.as_cmd_seq() for s in shapes], [s.clip_rule for s in shapes]
-        )
+def intersection(shapes: Iterable[SVGShape]) -> Generator[SVGCommand, None, None]:
+    return svg_pathops.intersection(
+        [s.as_cmd_seq() for s in shapes], [s.clip_rule for s in shapes]
     )

--- a/tests/outside-viewbox-clipped.svg
+++ b/tests/outside-viewbox-clipped.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <rect fill="blue" x="2" y="2" width="6" height="2"/>
+  <!-- partially out of bounds -->
+  <path fill="darkgreen" d="M7,5 C7,3.8954 7.8954,3 9,3 C9.3643,3 9.7058,3.0974 10,3.2676 L10,6.7324 C9.7058,6.9026 9.3643,7 9,7 C7.8954,7 7,6.1046 7,5 Z"/>
+  <!-- entirely out of bounds -->
+</svg>

--- a/tests/outside-viewbox.svg
+++ b/tests/outside-viewbox.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink">
+  <rect x="2" y="2" width="6" height="2" fill="blue" />
+  <!-- partially out of bounds -->
+  <circle cx="9" cy="5" r="2" fill="darkgreen" />
+  <!-- entirely out of bounds -->
+  <circle cx="5" cy="13" r="3" fill="red" />
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -273,6 +273,16 @@ def test_topicosvg(actual, expected_result):
 
 
 @pytest.mark.parametrize(
+    "actual, expected_result",
+    [
+        ("outside-viewbox.svg", "outside-viewbox-clipped.svg"),
+    ],
+)
+def test_clip_to_viewbox(actual, expected_result):
+    _test(actual, expected_result, lambda svg: svg.clip_to_viewbox().round_floats(4))
+
+
+@pytest.mark.parametrize(
     "actual, expected_result", [("invisible-before.svg", "invisible-after.svg")]
 )
 def test_remove_unpainted_shapes(actual, expected_result):


### PR DESCRIPTION
If entirely outside, goodbye. If partially outside, clipped. Does not attempt to resolve transforms, etc; just destroys content outside. Presumed typical use is to convert to picosvg and only then clip to viewbox.

Meant to power https://github.com/googlefonts/nanoemoji/issues/200.