### PR TITLE
Don't apply blank attributes

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -132,7 +132,7 @@ def from_element(el):
     args = {
         f.name: f.type(el.attrib[_attr_name(f.name)])
         for f in dataclasses.fields(data_type)
-        if _attr_name(f.name) in el.attrib
+        if el.attrib.get(_attr_name(f.name), "").strip()
     }
     return data_type(**args)
 

--- a/tests/svg_test_helpers.py
+++ b/tests/svg_test_helpers.py
@@ -26,7 +26,9 @@ def load_test_svg(filename):
 
 
 def svg_string(*els):
-    root = etree.fromstring('<svg version="1.1" xmlns="http://www.w3.org/2000/svg"/>')
+    root = etree.fromstring(
+        '<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"/>'
+    )
     for el in els:
         root.append(etree.fromstring(el))
     return etree.tostring(root)


### PR DESCRIPTION
Avoid replacing the default when an attribute is blank to prevent issues like https://github.com/googlefonts/nanoemoji/issues/229.