### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# 4 space indentation
+[*.{ini,py,py.tpl,rst}]
+indent_size = 4
+
+# 2 space indentation
+[*.yml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adding the `.editorconfig` file helps to maintain a uniform format and reduce lint errors.

<img width="870" alt="lint-error" src="https://user-images.githubusercontent.com/2784308/107313732-169b0f00-6ace-11eb-8428-b45017a2826e.png">

Reference template: 
* https://github.com/django/django/blob/master/.editorconfig
* https://github.com/seanfisk/python-project-template/blob/master/.editorconfig