### PR TITLE
Fix: Prevent errors when there is whitespace in front of `<?xml ?>`

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -1016,6 +1016,9 @@ class SVG:
         if isinstance(string, bytes):
             string = string.decode("utf-8")
 
+        # Prevent errors when there is whitespace in front of `<?xml ?>`.
+        string = string.strip()
+
         # svgs are fond of not declaring xlink
         # based on https://mailman-mail5.webfaction.com/pipermail/lxml/20100323/021184.html
         if "xlink" in string and "xmlns:xlink" not in string:

--- a/tests/drop-whitespace-after.svg
+++ b/tests/drop-whitespace-after.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+    <defs />
+</svg>

--- a/tests/drop-whitespace-before.svg
+++ b/tests/drop-whitespace-before.svg
@@ -1,0 +1,8 @@
+
+
+
+<?xml version="1.0" encoding="utf-8"?>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -272,6 +272,7 @@ def test_transform(actual, expected_result):
         ("ungroup-with-ids-before.svg", "ungroup-with-ids-nano.svg"),
         ("stroke-with-id-before.svg", "stroke-with-id-nano.svg"),
         ("drop-title-before.svg", "drop-title-after.svg"),
+        ("drop-whitespace-before.svg", "drop-whitespace-after.svg"),
     ],
 )
 def test_topicosvg(actual, expected_result):


### PR DESCRIPTION
XMLSyntaxError

```shell
lxml.etree.XMLSyntaxError: XML declaration allowed only at the start of the document
```