### PR TITLE
fix un-grouping when inherited transform == identity

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -416,6 +416,8 @@ class SVG:
                 transform = group_transform
             if transform != Affine2D.identity():
                 child.attrib[attr_name] = transform.tostring()
+            else:
+                del child.attrib[attr_name]
 
         attrib_handlers = {
             "clip-rule": _inherit_copy,

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -210,6 +210,7 @@ def test_resolve_use(actual, expected_result):
         ("ungroup-before.svg", "ungroup-after.svg"),
         ("ungroup-multiple-children-before.svg", "ungroup-multiple-children-after.svg"),
         ("twemoji-lesotho-flag-before.svg", "twemoji-lesotho-flag-after-ungroup.svg"),
+        ("ungroup-transform-before.svg", "ungroup-transform-after.svg"),
     ],
 )
 def test_ungroup(actual, expected_result):
@@ -276,6 +277,7 @@ def test_transform(actual, expected_result):
         ("decimal-viewbox-before.svg", "decimal-viewbox-nano.svg"),
         ("inkscape-noise-before.svg", "inkscape-noise-nano.svg"),
         ("flag-use-before.svg", "flag-use-nano.svg"),
+        ("ungroup-transform-before.svg", "ungroup-transform-nano.svg"),
     ],
 )
 def test_topicosvg(actual, expected_result):

--- a/tests/ungroup-transform-after.svg
+++ b/tests/ungroup-transform-after.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 24 24">
+  <rect id="r1" x="9" y="9" width="5" height="5" fill="red"/>
+  <rect id="r2" x="9" y="9" width="5" height="5"/>
+</svg>

--- a/tests/ungroup-transform-before.svg
+++ b/tests/ungroup-transform-before.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 24 24">
+  <rect id="r1" x="9" y="9" width="5" height="5" fill="red"/>
+  <g transform="translate(-6 0)">
+    <rect id="r2" x="9" y="9" width="5" height="5" transform="translate(6 0)"/>
+  </g>
+</svg>

--- a/tests/ungroup-transform-nano.svg
+++ b/tests/ungroup-transform-nano.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 24 24">
+  <defs/>
+  <path id="r1" fill="red" d="M9,9 H14 V14 H9 V9 Z"/>
+  <path id="r2" d="M9,9 H14 V14 H9 V9 Z"/>
+</svg>
+


### PR DESCRIPTION
When we remove `<g>` elements and matrix-multiply a parent group's transform with a child's own transform, if the result is identity (the two transforms cancel out each other) then we need to ensure we delete the transform attribute on the child element (so it will default to identity). Otherwise things get messed up, e.g. noto-emoji/third_party/region-flags/svg/SV.svg

before:

<img width="200" alt="Screenshot 2021-03-09 at 18 25 41" src="https://user-images.githubusercontent.com/6939968/110519543-5e30ad00-8105-11eb-8eda-08e4cd5cd4d3.png">


after:

<img width="200" alt="Screenshot 2021-03-09 at 18 29 08" src="https://user-images.githubusercontent.com/6939968/110519549-5ffa7080-8105-11eb-9cfa-6807a5330091.png">
