### PR TITLE
svg_transform: add decompose_scale and decompose_translation

### DIFF
--- a/src/picosvg/geometric_types.py
+++ b/src/picosvg/geometric_types.py
@@ -16,11 +16,11 @@ import math
 from typing import NamedTuple, Optional, Union
 
 
-_DEFAULT_ALMOST_EQUAL_TOLERANCE = 1e-9
+DEFAULT_ALMOST_EQUAL_TOLERANCE = 1e-9
 _PointOrVec = Union["Point", "Vector"]
 
 
-def almost_equal(c1, c2, tolerance=_DEFAULT_ALMOST_EQUAL_TOLERANCE) -> bool:
+def almost_equal(c1, c2, tolerance=DEFAULT_ALMOST_EQUAL_TOLERANCE) -> bool:
     return abs(c1 - c2) <= tolerance
 
 
@@ -56,7 +56,7 @@ class Point(NamedTuple):
         return Point(round(self.x, digits), round(self.y, digits))
 
     def almost_equals(
-        self, other: "Point", tolerance=_DEFAULT_ALMOST_EQUAL_TOLERANCE
+        self, other: "Point", tolerance=DEFAULT_ALMOST_EQUAL_TOLERANCE
     ) -> bool:
         return almost_equal(self.x, other.x, tolerance) and almost_equal(
             self.y, other.y, tolerance


### PR DESCRIPTION
Needed in nanoemoji to fix https://github.com/googlefonts/nanoemoji/issues/243

when mapping SVG radial gradients to font space in nanoemoji, we want to pre-apply as much transform as we can to the gradient geometry, thus we need to extract the scale and translation components from an Affine2D.
This PR adds a decompose_scale (copied from SkMatrix) and a decompose_translation (mutuated from Rod's code used for apply gradient translation).