### PR TITLE
some flags contain the old HTML <comment> elements, strip that too

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -845,7 +845,7 @@ class SVG:
 
         self._update_etree()
 
-        for tag in ("title", "desc", "metadata"):
+        for tag in ("title", "desc", "metadata", "comment"):
             for el in self.xpath(f"//svg:{tag}"):
                 el.getparent().remove(el)
 

--- a/tests/drop-title-meta-desc-before.svg
+++ b/tests/drop-title-meta-desc-before.svg
@@ -2,5 +2,6 @@
   <title>This is a svg title</title>
   <desc>A lengthy description</desc>
   <metadata>All my very best metadata</metadata>
+  <comment>This is an old Mosaic and Microsoft Internet Explorer tag. It was never added to the HTML specification and is not supported by modern browsers.</comment>
   <path id="heart" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
 </svg>


### PR DESCRIPTION
namely the Puertorican flag (PR.svg)

More info on the old comment tag https://html.com/tags/old-comment-tag/

(btw, I'm getting there, just 4 flags to go..)