### PR TITLE
strip id when copying stop from gradient template

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -989,7 +989,10 @@ class SVG:
             # only copy stops if we don't have our own
             if len(gradient) == 0:
                 for stop_el in template:
-                    gradient.append(copy.deepcopy(stop_el))
+                    new_stop_el = copy.deepcopy(stop_el)
+                    # strip stop id if present; useless and no longer unique
+                    _del_attrs(new_stop_el, "id")
+                    gradient.append(new_stop_el)
 
             del gradient.attrib[href_attr]
 

--- a/tests/gradient-template-1-before.svg
+++ b/tests/gradient-template-1-before.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1200" height="600">
   <defs>
     <linearGradient id="gradbase" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#a43907" stop-opacity="0.9961" offset="0"/>
-      <stop stop-color="#fff" offset="1"/>
+      <stop id="stop1" stop-color="#a43907" stop-opacity="0.9961" offset="0"/>
+      <stop id="stop2" stop-color="#fff" offset="1"/>
     </linearGradient>
     <linearGradient id="grad1" xlink:href="#gradbase" x1="826.45044" y1="419.93194" x2="786.12402" y2="396.11032"/>
     <linearGradient id="grad2" xlink:href="#gradbase" x1="851.56865" y1="436.06697" x2="763.03312" y2="419.67318"/>


### PR DESCRIPTION
One noto-emoji region flag (TA.svg) contain useless id attributes for all elements, including `<stop>` ones. When we resolve gradient templates, we copy the stop elements from the template but then we incur in a fatal picosvg violation as we end up with non-unique ids. We can simply strip the stop id attributes as they don't have any use.