### PR TITLE
feat: the fromstring() and tostring() adds the option not to remove the xmlns:xlink attribute

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -1212,16 +1212,17 @@ class SVG:
         )
         self.elements = None
 
-    def toetree(self):
+    def toetree(self, fix_xlink_ns=True):
         self._update_etree()
-        self.svg_root = _fix_xlink_ns(self.svg_root)
+        if fix_xlink_ns:
+            self.svg_root = _fix_xlink_ns(self.svg_root)
         return copy.deepcopy(self.svg_root)
 
-    def tostring(self):
-        return etree.tostring(self.toetree()).decode("utf-8")
+    def tostring(self, fix_xlink_ns=True):
+        return etree.tostring(self.toetree(fix_xlink_ns)).decode("utf-8")
 
     @classmethod
-    def fromstring(cls, string):
+    def fromstring(cls, string, fix_xlink_ns=True):
         if isinstance(string, bytes):
             string = string.decode("utf-8")
 
@@ -1233,7 +1234,8 @@ class SVG:
         # encode because fromstring dislikes xml encoding decl if input is str
         parser = etree.XMLParser(remove_blank_text=True)
         tree = etree.fromstring(string.encode("utf-8"), parser)
-        tree = _fix_xlink_ns(tree)
+        if fix_xlink_ns:
+            tree = _fix_xlink_ns(tree)
         return cls(tree)
 
     @classmethod

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -372,6 +372,34 @@ def test_remove_attributes(svg_string, names, expected_result):
     ) == expected_result
 
 
+@pytest.mark.parametrize(
+    "svg_string, remove_xmlns_xlink, expected_result",
+    [
+        # No change
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1"/>',
+            True,
+            '<svg xmlns="http://www.w3.org/2000/svg" version="1.1"/>',
+        ),
+        # Drop xmlns:xlink
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="7 7 12 12" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"/>',
+            True,
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="7 7 12 12" version="1.1"/>',
+        ),
+        # Don't drop xmlns:xlink
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="7 7 12 12" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"/>',
+            False,
+            '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="7 7 12 12" version="1.1"/>',
+        ),
+    ],
+)
+def test_remove_xmlns_xlink(svg_string, remove_xmlns_xlink, expected_result):
+    assert (
+        SVG.fromstring(svg_string, remove_xmlns_xlink).tostring(remove_xmlns_xlink)
+    ) == expected_result
+
 # https://github.com/rsheeter/picosvg/issues/1
 @pytest.mark.parametrize(
     "svg_string, expected_result",


### PR DESCRIPTION
This option is turned on by default. It needs to be turned off in the SVG in OT format, otherwise the use element will not be recognized in Safari.