### PR TITLE
parse radialGradient radius as percentage of viewport diagonal, not width

### DIFF
--- a/src/picosvg/svg_types.py
+++ b/src/picosvg/svg_types.py
@@ -15,6 +15,7 @@
 import copy
 import dataclasses
 from itertools import zip_longest
+import math
 import re
 from picosvg.geometric_types import Point, Rect
 from picosvg.svg_meta import (
@@ -836,10 +837,13 @@ class SVGRadialGradient:
     def from_element(el, view_box) -> "SVGRadialGradient":
         self = SVGRadialGradient()
         width, height = _parse_common_gradient_parts(self, el, view_box)
+        # lengths are calculated as percentages of the "normalized diagonal" of the
+        # SVG viewport. See formula at https://www.w3.org/TR/SVG2/coords.html#Units
+        diagonal = math.hypot(width, height) / math.sqrt(2)
 
         self.cx = number_or_percentage(el.attrib.get("cx", "50%"), width)
         self.cy = number_or_percentage(el.attrib.get("cy", "50%"), height)
-        self.r = number_or_percentage(el.attrib.get("r", "50%"), width)
+        self.r = number_or_percentage(el.attrib.get("r", "50%"), diagonal)
 
         raw_fx = el.attrib.get("fx")
         self.fx = number_or_percentage(raw_fx, width) if raw_fx is not None else self.cx
@@ -847,7 +851,7 @@ class SVGRadialGradient:
         self.fy = (
             number_or_percentage(raw_fy, height) if raw_fy is not None else self.cy
         )
-        self.fr = number_or_percentage(el.attrib.get("fr", "0%"), width)
+        self.fr = number_or_percentage(el.attrib.get("fr", "0%"), diagonal)
         return self
 
 


### PR DESCRIPTION
currently we do:

https://github.com/googlefonts/picosvg/blob/9d00851d8bc25616116836f826e3d7089492312f/src/picosvg/svg_types.py#L842

But the [SVG spec](https://www.w3.org/TR/SVG2/coords.html#Units) says


> For any other length value expressed as a percentage of the SVG viewport, the percentage must be calculated as a percentage of the normalized diagonal of the ‘viewBox’ applied to that viewport. If no ‘viewBox’ is specified, then the normalized diagonal of the SVG viewport must be used. The normalized diagonal length must be calculated with sqrt((width)**2 + (height)**2)/sqrt(2).

So we should do the right thing (even if percentages usually are used with objectBoundingBox where the unit square by definition is width==height==1).

I push the failing test first, then the fix
