### PR TITLE
Affine2D: define __matmul__ infix operator; deprecate product()

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -649,8 +649,8 @@ class SVG:
             transform = Affine2D.identity()
             while el is not None:
                 if "transform" in el.attrib:
-                    transform = Affine2D.product(
-                        transform, Affine2D.fromstring(el.attrib["transform"])
+                    transform = Affine2D.compose_ltr(
+                        (transform, Affine2D.fromstring(el.attrib["transform"]))
                     )
                 el = el.getparent()
             if transform == Affine2D.identity():
@@ -1211,12 +1211,11 @@ def _inherit_nondefault_overflow(attrib, child, attr_name):
 
 
 def _inherit_matrix_multiply(attrib, child, attr_name):
-    group_transform = Affine2D.fromstring(attrib[attr_name])
+    transform = Affine2D.fromstring(attrib[attr_name])
     if attr_name in child.attrib:
-        transform = Affine2D.fromstring(child.attrib[attr_name])
-        transform = Affine2D.product(transform, group_transform)
-    else:
-        transform = group_transform
+        transform = Affine2D.compose_ltr(
+            (Affine2D.fromstring(child.attrib[attr_name]), transform)
+        )
     if transform != Affine2D.identity():
         child.attrib[attr_name] = transform.tostring()
     else:

--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -79,7 +79,10 @@ class Affine2D(NamedTuple):
         return f'matrix({" ".join(ntos(v) for v in self)})'
 
     def __matmul__(self, other: "Affine2D") -> "Affine2D":
-        """Returns the product of first × second. Order matters.
+        """Returns the product of self × other. Order matters.
+
+        The combined affine matrix can be thought of mapping by other before applying self.
+
         https://en.wikipedia.org/wiki/Matrix_multiplication
 
                 | a₁  c₁  e₁ |

--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -19,6 +19,7 @@ Focuses on converting to a sequence of affine matrices.
 import collections
 from functools import reduce
 from math import cos, sin, radians, tan, hypot
+import operator
 import re
 from typing import NamedTuple, Sequence, Tuple
 from sys import float_info
@@ -77,23 +78,50 @@ class Affine2D(NamedTuple):
             return f'translate({", ".join(ntos(v) for v in self.gettranslate())})'
         return f'matrix({" ".join(ntos(v) for v in self)})'
 
-    @staticmethod
-    def product(first: "Affine2D", second: "Affine2D") -> "Affine2D":
-        """Returns the product of first x second.
+    def __matmul__(self, other: "Affine2D") -> "Affine2D":
+        """Returns the product of first × second. Order matters.
+        https://en.wikipedia.org/wiki/Matrix_multiplication
 
-        Order matters; meant to make that a bit more explicit.
+                | a₁  c₁  e₁ |
+        first = | b₁  d₁  f₁ |
+                | 0   0   1  |
+
+                 | a₂  c₂  e₂ |
+        second = | b₂  d₂  f₂ |
+                 | 0   0   1  |
+
+                         | a₁·a₂ + c₁·b₂ + e₁·0  a₁·c₂ + c₁·d₂ + e₁·0  a₁·e₂ + c₁·f₂ + e₁·1 |
+        first × second = | b₁·a₂ + d₁·b₂ + f₁·0  b₁·c₂ + d₁·d₂ + f₁·0  b₁·e₂ + d₁·f₂ + f₁·1 |
+                         |  0·a₂ +  0·b₂ +  1·0   0·c₂ +  0·d₂ +  1·0   0·e₂ +  0·f₂ +  1·1 |
         """
+        if not isinstance(other, Affine2D):
+            return NotImplemented
         return Affine2D(
-            first.a * second.a + first.b * second.c,
-            first.a * second.b + first.b * second.d,
-            first.c * second.a + first.d * second.c,
-            first.c * second.b + first.d * second.d,
-            second.a * first.e + second.c * first.f + second.e,
-            second.b * first.e + second.d * first.f + second.f,
+            a=self.a * other.a + self.c * other.b,  # + self.e * 0
+            b=self.b * other.a + self.d * other.b,  # + self.f * 0
+            c=self.a * other.c + self.c * other.d,  # + self.e * 0
+            d=self.b * other.c + self.d * other.d,  # + self.f * 0
+            e=self.a * other.e + self.c * other.f + self.e,  # * 1
+            f=self.b * other.e + self.d * other.f + self.f,  # * 1
         )
 
+    __imatmul__ = __matmul__
+
+    @staticmethod
+    def product(first: "Affine2D", second: "Affine2D") -> "Affine2D":
+        """Returns the product of second x first. DEPRECATED - use '@' infix operator"""
+        import warnings
+
+        warnings.warn(
+            "'product' is deprecated; use '@' infix operator",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return second @ first
+
     def matrix(self, a, b, c, d, e, f):
-        return Affine2D.product(Affine2D(a, b, c, d, e, f), self)
+        return self @ Affine2D(a, b, c, d, e, f)
 
     # https://www.w3.org/TR/SVG11/coords.html#TranslationDefined
     def translate(self, tx, ty=0):
@@ -168,9 +196,7 @@ class Affine2D(NamedTuple):
 
         Affines apply like functions - f(g(x)) - so we merge them in reverse order.
         """
-        return reduce(
-            lambda acc, a: cls.product(a, acc), reversed(affines), cls.identity()
-        )
+        return reduce(operator.matmul, reversed(affines), cls.identity())
 
     def round(self, digits: int) -> "Affine2D":
         return Affine2D(*(round(v, digits) for v in self))

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -263,24 +263,23 @@ class TestAffine2D:
         affine1 = Affine2D.identity().rotate(pi / 2)
         affine2 = Affine2D.identity().translate(1, 1)
         p0 = Point(1, 1)
-        assert Affine2D.product(affine1, affine2).map_point(p0).round(
-            2
-        ) == affine2.map_point(affine1.map_point(p0)).round(2)
+        expected = affine2.map_point(affine1.map_point(p0)).round(2)
+        assert (affine2 @ affine1).map_point(p0).round(2) == expected
+        # deprecated
+        assert Affine2D.product(affine1, affine2).map_point(p0).round(2) == expected
 
     def test_product_ordering(self):
         affine1 = Affine2D.identity().rotate(pi / 2)
         affine2 = Affine2D.identity().rotate(pi / 2, cx=0, cy=1)
 
-        assert Affine2D.product(affine1, affine2) != Affine2D.product(affine2, affine1)
+        assert (affine2 @ affine1) != (affine1 @ affine2)
 
         # Start at 1,0.
         # Rotate 90° around 0,0 to get 0,1
         # Rotate a further 90° around 0,1 to get ... still 0,1
         # Truly mind blowing stuff.
         p0 = Point(1, 0)
-        assert (Affine2D.product(affine1, affine2).map_point(p0).round(2)) == Point(
-            0, 1
-        ).round(2)
+        assert ((affine2 @ affine1).map_point(p0).round(2)) == Point(0, 1).round(2)
 
     def test_gettranslate(self):
         af = Affine2D.identity()


### PR DESCRIPTION
The product staticmethod is wrong, instead of matrix-multiplying first x second, it was doing the opposite, second x first.

This PR adds `__matmul__` infix operator ('@') for correct matrix multiplication, and deprecates the old incorrect product() method, temporarily kept only for backward compatibility