### PR TITLE
allow to run evenodd_to_nonzero_winding method in isolation

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -672,9 +672,11 @@ class SVG:
             svg.evenodd_to_nonzero_winding(inplace=True)
             return svg
 
-        for shape in self.shapes():
+        for idx, (el, (shape,)) in enumerate(self._elements()):
             if shape.fill_rule == "evenodd":
-                shape.remove_overlaps(inplace=True)
+                path = shape.as_path().remove_overlaps(inplace=True)
+                self._set_element(idx, el, (path,))
+
         return self
 
     def round_floats(self, ndigits: int, inplace=False):

--- a/tests/fill-rule-evenodd-after.svg
+++ b/tests/fill-rule-evenodd-after.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-10 -10 220 120">
+  <!-- Default value for fill-rule -->
+  <polygon stroke="red" points="50,0 21,90 98,35 2,35 79,90"/>
+  <!--
+  The center of the shape has two
+  path segments (shown by the red stroke)
+  between it and infinity. It is therefore
+  considered outside the shape, and not filled.
+  -->
+  <path stroke="red" d="M150,0 L161.278,35 L138.722,35 Z M131.852,56.323 L102,35 L138.722,35 L131.852,56.323 Z M198,35 L168.148,56.323 L161.278,35 L198,35 Z M121,90 L131.852,56.323 L150,69.286 L121,90 Z M168.148,56.323 L179,90 L150,69.286 L168.148,56.323 Z"/>
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -577,3 +577,17 @@ def test_tostring_pretty_print():
         </svg>
         """
     )
+
+
+@pytest.mark.parametrize(
+    "actual, expected_result",
+    [
+        ("fill-rule-evenodd-before.svg", "fill-rule-evenodd-after.svg"),
+    ],
+)
+def test_evenodd_to_nonzero_winding(actual, expected_result):
+    _test(
+        actual,
+        expected_result,
+        lambda svg: svg.evenodd_to_nonzero_winding().round_floats(3, inplace=True),
+    )


### PR DESCRIPTION
currently `evenodd_to_nonzero_winding` method fails if `shapes_to_paths` is not called first. That's because `remove_overlaps` method is only defined on `SVGPath` class, not on the rest of the SVGShapes.
Sometimes one may want to be able to only run `evenodd_to_nonzero_winding` without applying the rest of the topicosvg filters.
This patch allows to do that, by first calling `SVGShape.as_path()` and then `remove_overlaps`.