### PR TITLE
drop support for python3.6, require >= 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         platform: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ pip install -e .
 picosvg mysvg.svg
 ```
 
+Requires Python 3.7 or greater.
+
 ## Test
 
 Install the dev dependencies specified in [`extras_require`](https://github.com/googlefonts/picosvg/blob/main/setup.py#L36-L40).

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup_args = dict(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "absl-py>=0.9.0",
-        "dataclasses>=0.7; python_version < '3.7'",
         "lxml>=4.0",
         "skia-pathops>=0.6.0",
     ],
@@ -40,7 +39,8 @@ setup_args = dict(
             "pytype==2020.11.23; python_version < '3.9'",
         ],
     },
-    python_requires=">=3.6",
+    # this is so we can use the built-in dataclasses module
+    python_requires=">=3.7",
 
     # this is for type checker to use our inline type hints:
     # https://www.python.org/dev/peps/pep-0561/#id18

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 ;   $ export TOXENV=py39
 ;   $ tox
 ;     # If present use $TOXENV environment variable
-envlist = lint, py3{6,7,8,9}
+envlist = lint, py3{7,8,9}
 
 ; if any of the requested python interpreters is unavailable (e.g. on the local dev
 ; workstation), the tests are skipped and tox won't return an error


### PR DESCRIPTION
As we discussed in https://github.com/googlefonts/picosvg/pull/223#issuecomment-870229523

picosvg relies on dataclasses module. The backport available for pythons < 3.7 contains some bugs that makes it impossible to use features like `dataclasses.asdict` or `dataclasses.replace`.