### PR TITLE
fix incorrect inverse affine transform dy component

### DIFF
--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -171,8 +171,7 @@ class Affine2D(NamedTuple):
         a, b, c, d, e, f = self
         det = self.determinant()
         a, b, c, d = d / det, -b / det, -c / det, a / det
-        e = -a * e - c * f
-        f = -b * e - d * f
+        e, f = -a * e - c * f, -b * e - d * f
         return self.__class__(a, b, c, d, e, f)
 
     def map_point(self, pt: Tuple[float, float]) -> Point:

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -117,13 +117,35 @@ class TestAffine2D:
         assert Affine2D.identity().scale(0, 0).is_degenerate()
 
     @pytest.mark.parametrize(
+        "transform, inverse",
+        [
+            (
+                Affine2D.identity().translate(2, 3).scale(4, 5),
+                Affine2D(a=0.25, b=0.0, c=0.0, d=0.2, e=-0.5, f=-0.6),
+            ),
+            (
+                Affine2D(0, -2.875, 2.875, 0, 2.39, 250.81),
+                Affine2D(0.0, 0.348, -0.348, 0.0, 87.238, -0.831),
+            ),
+        ],
+    )
+    def test_inverse(self, transform, inverse):
+        assert transform.inverse().almost_equals(inverse, 1e-3)
+        assert (transform @ transform.inverse()).almost_equals(
+            Affine2D.identity()
+        )
+        assert (transform.inverse() @ transform).almost_equals(
+            Affine2D.identity()
+        )
+
+    @pytest.mark.parametrize(
         "transform",
         [
             Affine2D.identity().translate(2, 3).scale(4, 5),
             Affine2D(0, -2.875, 2.875, 0, 2.39, 250.81),
         ],
     )
-    def test_inverse(self, transform):
+    def test_inverse_roundtrip(self, transform):
         p0 = Point(12, 34)
         p1 = transform.map_point(p0)
         it = transform.inverse()

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -116,14 +116,21 @@ class TestAffine2D:
         assert Affine2D.identity().scale(1, 0).is_degenerate()
         assert Affine2D.identity().scale(0, 0).is_degenerate()
 
-    def test_inverse(self):
-        t = Affine2D.identity().translate(2, 3).scale(4, 5)
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            Affine2D.identity().translate(2, 3).scale(4, 5),
+            Affine2D(0, -2.875, 2.875, 0, 2.39, 250.81),
+        ],
+    )
+    def test_inverse(self, transform):
         p0 = Point(12, 34)
-        p1 = t.map_point(p0)
-        it = t.inverse()
+        p1 = transform.map_point(p0)
+        it = transform.inverse()
         p2 = it.map_point(p1)
         assert p2 == p0
 
+    def test_inverse_degenerate(self):
         assert Affine2D.degenerate().inverse() == Affine2D.degenerate()
         t = Affine2D(1, 1, 1, 1, 0, 0).inverse()
         assert t.is_degenerate()

--- a/tests/svg_transform_test.py
+++ b/tests/svg_transform_test.py
@@ -131,12 +131,8 @@ class TestAffine2D:
     )
     def test_inverse(self, transform, inverse):
         assert transform.inverse().almost_equals(inverse, 1e-3)
-        assert (transform @ transform.inverse()).almost_equals(
-            Affine2D.identity()
-        )
-        assert (transform.inverse() @ transform).almost_equals(
-            Affine2D.identity()
-        )
+        assert (transform @ transform.inverse()).almost_equals(Affine2D.identity())
+        assert (transform.inverse() @ transform).almost_equals(Affine2D.identity())
 
     @pytest.mark.parametrize(
         "transform",


### PR DESCRIPTION
While debugging googlefonts/nanoemoji#339 (comment), I stumbled on an affine `(0, -2.875, 2.875, 0, 2.39, 250.81)` whose inverse, when combined with self, did not give me back identity..

I was expecting the inverse to be (0.0, 0.348, -0.348, 0.0, 87.238, -0.831), whereas I was getting (0.0, 0.348, -0.348, 0.0, 87.238, -30.344).

It turned out the Affine2D.inverse() method was incorrectly computing its `dy` (or `f`) component for the inverse matrix.

The local variable `e` was being reassigned, thus influencing the calculation of `f` in the following statement. 
The fix itself explains better than any words:

```diff
diff --git a/src/picosvg/svg_transform.py b/src/picosvg/svg_transform.py
index 5e519bf..f2664ef 100644
--- a/src/picosvg/svg_transform.py
+++ b/src/picosvg/svg_transform.py
@@ -171,8 +171,7 @@ class Affine2D(NamedTuple):
         a, b, c, d, e, f = self
         det = self.determinant()
         a, b, c, d = d / det, -b / det, -c / det, a / det
-        e = -a * e - c * f
-        f = -b * e - d * f
+        e, f = -a * e - c * f, -b * e - d * f
         return self.__class__(a, b, c, d, e, f)

     def map_point(self, pt: Tuple[float, float]) -> Point:
```