### PR TITLE
affine_between: return None instead of assert when no significant x part is found

### DIFF
--- a/src/picosvg/svg_reuse.py
+++ b/src/picosvg/svg_reuse.py
@@ -216,7 +216,11 @@ def affine_between(s1: SVGShape, s2: SVGShape, tolerance: float) -> Optional[Aff
     # Align the first edge with a significant x part.
     # Fixes rotation, x-scale, and uniform scaling.
     s2_vec1x_idx, s2_vec1x = _first_significant(_vectors(s2), lambda v: v.x, tolerance)
-    assert s2_vec1x_idx != -1
+    if s2_vec1x_idx == -1:
+        # bail out if we find no first edge with significant x part
+        # https://github.com/googlefonts/picosvg/issues/246
+        return None
+
     s1_vec1 = _nth_vector(s1, s2_vec1x_idx)
 
     s1_to_origin = Affine2D.identity().translate(-s1x, -s1y)


### PR DESCRIPTION
Fixes https://github.com/googlefonts/picosvg/issues/246

or at least it works around the bug...

```python
from picosvg.svg_types import SVGPath
from picosvg.svg_reuse import normalize, affine_between

s1 = SVGPath(d="M753.2400512695312,405.12799072265625 l0,-17.5560302734375 l-1.17608642578125,0.156005859375 l0,17.5560302734375 l1.17608642578125,-0.156005859375")

s2 = SVGPath(d="M523.7760009765625,465.91998291015625 l-0.22796630859375,-5.42401123046875 l-0.43206787109375,0.09600830078125 l0.22802734375,5.399993896484375 l0.4320068359375,-0.071990966796875")

tolerance = 0.1

assert normalize(s1, tolerance) == normalize(s2, tolerance)

affine_between(s1, s2, tolerance)  # this fails with AssertionError
```