### PR TITLE
Accept none for clip-path

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -611,7 +611,7 @@ class SVG:
                     continue
                 transform = _element_transform(child, context.transform)
                 clips = context.clips
-                if "clip-path" in child.attrib:
+                if "clip-path" in child.attrib and child.attrib["clip-path"] != "none":
                     clips += (
                         self._resolve_clip_path(child.attrib["clip-path"], transform),
                     )

--- a/tests/clip-clippath-none-nano.svg
+++ b/tests/clip-clippath-none-nano.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="Layer_1" viewBox="0 0 10 10">
+  <defs/>
+  <path d="M9,4 A3 3 0 1 1 3,4 A3 3 0 1 1 9,4 Z"/>
+</svg>

--- a/tests/clip-clippath-none.svg
+++ b/tests/clip-clippath-none.svg
@@ -1,0 +1,8 @@
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+viewBox="0 0 10 10">
+  <g>
+    <g style="clip-path:none">
+      <circle cx="6" cy="4" r="3" />
+    </g>
+  </g>
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -203,6 +203,7 @@ def test_resolve_use(actual, expected_result):
         ("clip-use.svg", "clip-use-clipped-nano.svg"),
         ("clip-rule-evenodd.svg", "clip-rule-evenodd-clipped-nano.svg"),
         ("clip-clippath-attrs.svg", "clip-clippath-attrs-nano.svg"),
+        ("clip-clippath-none.svg", "clip-clippath-none-nano.svg"),
         ("rotated-rect.svg", "rotated-rect-nano.svg"),
         ("translate-rect.svg", "translate-rect-nano.svg"),
         ("ungroup-before.svg", "ungroup-nano.svg"),


### PR DESCRIPTION
“none” is one of the accepted “clip-path” values:

> https://www.w3.org/TR/SVG11/masking.html#ClipPathProperty

Accept and ignore the clip in this case.

Inkscape sometimes output it (when the object has a clip, then the clip
is released).