### PR TITLE
Made picosvg ignore <?xpacket?> tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .eggs/
 src/picosvg/_version.py
 .tox/
+.*.swp

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -661,3 +661,10 @@ def test_topicosvg_ndigits(inplace):
         '<path d="M60.5,30 L100.1,30 L100.1,70 L60.5,70 Z"/>'
         "</svg>"
     )
+
+
+def test_xpacket():
+    xpacket_svg = load_test_svg("xpacket.svg")
+    assert "xpacket" in xpacket_svg.tostring()
+    pico_svg = xpacket_svg.topicosvg()
+    assert "xpacket" not in pico_svg.tostring()

--- a/tests/xpacket.svg
+++ b/tests/xpacket.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="512" height="512"
+     viewBox="0 0 30 30">
+  <metadata>
+    <?xpacket begin="" id=""?><?xpacket end="r"?>
+  </metadata>
+  <?xpacket begin="" id=""?><?xpacket end="r"?>
+  <ellipse
+           cx="14" cy="10" 
+           rx="8" ry="4"
+           opacity="0.5"/>
+</svg>


### PR DESCRIPTION
- Abstracted out "check if tag is a comment" into _is_redundant(tag).
- Added etree.ProcessingInstruction to the set of redundant tags.
- Created function to remove processing instructions.
- Changed topicosvg to remove processing instructions.
- Added test to ensure xpacket tags no longer break picosvg, and are
  actually removed when topicosvg is called.