### PR TITLE
Exploratory optional discard of all unsupported elements

### DIFF
--- a/src/picosvg/picosvg.py
+++ b/src/picosvg/picosvg.py
@@ -29,6 +29,11 @@ import sys
 FLAGS = flags.FLAGS
 
 
+flags.DEFINE_bool(
+    "drop_unsupported",
+    False,
+    "Whether to blindly discard all elements we don't understand. Likely unwise.",
+)
 flags.DEFINE_bool("clip_to_viewbox", False, "Whether to clip content outside viewbox")
 flags.DEFINE_string("output_file", "-", "Output SVG file ('-' means stdout)")
 flags.DEFINE_bool(
@@ -45,9 +50,14 @@ def _run(argv):
         input_file = None
 
     if input_file:
-        svg = SVG.parse(input_file).topicosvg(allow_text=FLAGS.allow_text)
+        svg = SVG.parse(input_file)
     else:
-        svg = SVG.fromstring(sys.stdin.read()).topicosvg(allow_text=FLAGS.allow_text)
+        svg = SVG.fromstring(sys.stdin.read())
+
+    # Do the needful
+    svg = svg.topicosvg(
+        allow_text=FLAGS.allow_text, drop_unsupported=FLAGS.drop_unsupported
+    )
 
     if FLAGS.clip_to_viewbox:
         svg.clip_to_viewbox(inplace=True)

--- a/tests/comments-before.svg
+++ b/tests/comments-before.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- I am a comment -->
+<svg id='svg' xmlns="http://www.w3.org/2000/svg"
+     width="512" height="512"
+     viewBox="0 0 24 24">
+  <!-- I am also a comment -->
+  <rect x="1" y="1" width="5" height="4" fill="blue" opacity="0.5"/>
+</svg>

--- a/tests/comments-image-style-before.svg
+++ b/tests/comments-image-style-before.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- I am a comment -->
+<svg id='svg' xmlns="http://www.w3.org/2000/svg"
+     width="512" height="512"
+     viewBox="0 0 24 24">
+  <style type="text/css">
+    I should be dropped!
+  </style>
+  <!-- I am also a comment -->
+  <image xlink:href="I should also be dropped" />
+  <rect x="1" y="1" width="5" height="4" fill="blue" opacity="0.5"/>
+</svg>

--- a/tests/comments-image-style-before.svg
+++ b/tests/comments-image-style-before.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- I am a comment -->
-<svg id='svg' xmlns="http://www.w3.org/2000/svg"
+<svg id='svg' xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
      width="512" height="512"
      viewBox="0 0 24 24">
   <style type="text/css">

--- a/tests/comments-image-style-nano.svg
+++ b/tests/comments-image-style-nano.svg
@@ -1,0 +1,6 @@
+<svg id='svg' xmlns="http://www.w3.org/2000/svg"
+     width="512" height="512"
+     viewBox="0 0 24 24">
+  <defs/>
+  <path fill="blue" opacity="0.5" d="M1,1 L6,1 L6,5 L1,5 L1,1 Z"/>
+</svg>

--- a/tests/comments-nano.svg
+++ b/tests/comments-nano.svg
@@ -1,0 +1,6 @@
+<svg id='svg' xmlns="http://www.w3.org/2000/svg"
+     width="512" height="512"
+     viewBox="0 0 24 24">
+  <defs/>
+  <path fill="blue" opacity="0.5" d="M1,1 L6,1 L6,5 L1,5 L1,1 Z"/>
+</svg>

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -288,10 +288,34 @@ def test_resolve_use(actual, expected_result):
             "xpacket-before.svg",
             "xpacket-nano.svg",
         ),
+        # https://github.com/googlefonts/picosvg/issues/297
+        # Demonstrate comments outside root drop just fine
+        (
+            "comments-before.svg",
+            "comments-nano.svg",
+        ),
     ],
 )
 def test_topicosvg(actual, expected_result):
     _test(actual, expected_result, lambda svg: svg.topicosvg())
+
+
+@pytest.mark.parametrize(
+    "actual, expected_result",
+    [
+        # https://github.com/googlefonts/picosvg/issues/297
+        (
+            "comments-image-style-before.svg",
+            "comments-image-style-nano.svg",
+        ),
+    ],
+)
+def test_topicosvg_drop_unsupported(actual, expected_result):
+    # This should fail unless we drop unsupported
+    with pytest.raises(ValueError) as e:
+        _test(actual, expected_result, lambda svg: svg.topicosvg())
+    assert "BadElement" in str(e.value)
+    _test(actual, expected_result, lambda svg: svg.topicosvg(drop_unsupported=True))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If `--drop_unsupported` is set picosvg will drop the element instead of failing and reporting BadElement. Fixes #297. 

For context, this is not a capability I wanted for our usage but since we now have some evidence people are rolling their own equivalent maybe we should just support it directly.

```shell
$ picosvg /tmp/uni7cb9.svg
blah blah blah
ValueError: Unable to convert to picosvg: BadElement: /svg[0]/style[0],BadElement: /svg[0]/image[0]
$ picosvg --drop_unsupported /tmp/uni7cb9.svg
(works)
```

~~EDIT: I believe the test failure is https://github.com/googlefonts/picosvg/issues/299 and not due to this PR~~ Fixed