### PR TITLE
use XMLParser with remove_comments=True

### DIFF
--- a/src/picosvg/svg.py
+++ b/src/picosvg/svg.py
@@ -1011,19 +1011,6 @@ class SVG:
 
         return self
 
-    def remove_comments(self, inplace=False):
-        if not inplace:
-            svg = self._clone()
-            svg.remove_comments(inplace=True)
-            return svg
-
-        self._update_etree()
-
-        for el in self.xpath("//comment()"):
-            el.getparent().remove(el)
-
-        return self
-
     def remove_anonymous_symbols(self, inplace=False):
         # No id makes a symbol useless
         # https://github.com/googlefonts/picosvg/issues/46
@@ -1359,7 +1346,6 @@ class SVG:
 
         # Discard useless content
         self.remove_nonsvg_content(inplace=True)
-        self.remove_comments(inplace=True)
         self.remove_processing_instructions(inplace=True)
         self.remove_anonymous_symbols(inplace=True)
         self.remove_title_meta_desc(inplace=True)
@@ -1444,7 +1430,7 @@ class SVG:
             string = string.replace("xlink:href", _XLINK_TEMP)
 
         # encode because fromstring dislikes xml encoding decl if input is str
-        parser = etree.XMLParser(remove_blank_text=True)
+        parser = etree.XMLParser(remove_comments=True, remove_blank_text=True)
         tree = etree.fromstring(string.encode("utf-8"), parser)
         tree = _fix_xlink_ns(tree)
         return cls(tree)

--- a/tests/svg_test.py
+++ b/tests/svg_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import dataclasses
+from copy import deepcopy
 from textwrap import dedent
 from lxml import etree
 import math
@@ -300,6 +301,7 @@ def test_topicosvg(actual, expected_result):
     _test(actual, expected_result, lambda svg: svg.topicosvg())
 
 
+@pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize(
     "actual, expected_result",
     [
@@ -310,12 +312,18 @@ def test_topicosvg(actual, expected_result):
         ),
     ],
 )
-def test_topicosvg_drop_unsupported(actual, expected_result):
+def test_topicosvg_drop_unsupported(actual, inplace, expected_result):
+    actual_copy = deepcopy(actual)
     # This should fail unless we drop unsupported
     with pytest.raises(ValueError) as e:
-        _test(actual, expected_result, lambda svg: svg.topicosvg())
+        _test(actual_copy, expected_result, lambda svg: svg.topicosvg(inplace=inplace))
     assert "BadElement" in str(e.value)
-    _test(actual, expected_result, lambda svg: svg.topicosvg(drop_unsupported=True))
+    actual_copy = deepcopy(actual)
+    _test(
+        actual_copy,
+        expected_result,
+        lambda svg: svg.topicosvg(inplace=inplace, drop_unsupported=True),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes Attribute error when attempting to remove comments with inplace=True and the comment has no parents.
Using the XMLParser(remove_comments=True) option does the trick

Fixes https://github.com/googlefonts/picosvg/issues/297